### PR TITLE
Add -moz vendor prefix to CSS

### DIFF
--- a/covervid.js
+++ b/covervid.js
@@ -17,6 +17,7 @@ jQuery.fn.extend({
                 'left': '50%',
                 '-webkit-transform': 'translate(-50%, -50%)',
                 '-ms-transform': 'translate(-50%, -50%)',
+                '-moz-transform': 'translate(-50%, -50%)',
                 'transform': 'translate(-50%, -50%)',
             });
 


### PR DESCRIPTION
Otherwise video container is `50%` from `top` and `left` in Firefox
