### PR TITLE
Better support for SPA

### DIFF
--- a/covervid.js
+++ b/covervid.js
@@ -39,6 +39,8 @@ var coverVid = function (elem, width, height) {
 	// Define the attached selector
 	function sizeVideo() {
 		
+		if (!elem.parentNode) { return; }
+		
 		// Get parent element height and width
 		var parentHeight = elem.parentNode.offsetHeight;
 		var parentWidth = elem.parentNode.offsetWidth;


### PR DESCRIPTION
If the video is no longer on the page, don't throw an error. Fixes #28.